### PR TITLE
Cc/feature/37/fetch specific patient data

### DIFF
--- a/gondorapi/views/records.py
+++ b/gondorapi/views/records.py
@@ -1,10 +1,18 @@
-from gondorapi.models import PatientData, User
-from .user import ClinicianSerializer 
+from gondorapi.models import PatientData, User, Log
+from .users import ClinicianSerializer 
 from rest_framework import viewsets, status, serializers
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from django.db.models import Q
 from django.contrib.auth.models import Group
+
+class PatientSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = User
+        fields = ["id", "first_name", "last_name", "fullName"]
+
+    def get_fullName(self,obj):
+        return f"{obj.first_name} {obj.last_name}"
 
 
 class PatientDataSerializer(serializers.ModelSerializer):
@@ -17,7 +25,42 @@ class PatientDataSerializer(serializers.ModelSerializer):
     def get_clinician(self,obj):
         serializer = ClinicianSerializer(obj.created_by)
         return serializer.data
+    
+class SpecificPatientDataSerializer(serializers.ModelSerializer):
+    clinician = serializers.SerializerMethodField()
+    updating_clinician = serializers.SerializerMethodField()
+    patient = serializers.SerializerMethodField()
 
+    class Meta:
+        model = PatientData
+        fields = ["id", "patient", "appointment", "clinician", "updating_clinician", "created_timestamp", "patient_diastolic", "patient_systolic", "is_notes_shared", "clinician_notes"]
+
+    def to_representation(self, instance):
+        rep = super().to_representation(instance)
+        rep["updatedClinician"] = rep.pop("updating_clinician")
+        rep["createdTimestamp"] = rep.pop("created_timestamp")
+        rep["patientDiastolic"] = rep.pop("patient_diastolic")
+        rep["patientSystolic"] = rep.pop("patient_systolic")
+        rep["isNotesShared"] = rep.pop("is_notes_shared")
+        rep["clinicianNotes"] = rep.pop("clinician_notes")
+        return rep
+    
+    def get_patient(self,obj):
+        serializer = PatientSerializer(obj.patient)
+        return serializer.data
+    
+    def get_clinician(self,obj):
+        serializer = ClinicianSerializer(obj.created_by)
+        return serializer.data
+    
+    def get_updating_clinician(self,obj):
+        serializer = ClinicianSerializer(obj.updated_by)
+        return serializer.data
+
+class CreateLogSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Log
+        fields = ["viewed_by", "patient_data", "created_timestamp"]
 
 class RecordViewSet(viewsets.ViewSet):
     @action(detail=False, methods=["get"], url_path="me")
@@ -41,3 +84,5 @@ class RecordViewSet(viewsets.ViewSet):
             return Response(serializer.data, status=status.HTTP_200_OK)
         
         return Response({"error": "Unauthorized access. Only patients can access their records"}, status=status.HTTP_400_BAD_REQUEST)
+    
+    

--- a/gondorapi/views/records.py
+++ b/gondorapi/views/records.py
@@ -84,6 +84,7 @@ class RecordViewSet(viewsets.ViewSet):
     
     def retrieve(self,request, pk=None):
         user = request.user
+        # using get_object_or_404 because when i tried patientData.objects.get it would tell me that patientData has not objects. but this works as intended.
         found_record = get_object_or_404(PatientData, id=pk)
         is_authorized_user = (
             found_record.patient == user or

--- a/gondorapi/views/records.py
+++ b/gondorapi/views/records.py
@@ -39,7 +39,7 @@ class SpecificPatientDataSerializer(serializers.ModelSerializer):
 
     def to_representation(self, instance):
         rep = super().to_representation(instance)
-        rep["updatedClinician"] = rep.pop("updating_clinician")
+        rep["updatingClinician"] = rep.pop("updating_clinician")
         rep["createdTimestamp"] = rep.pop("created_timestamp")
         rep["patientDiastolic"] = rep.pop("patient_diastolic")
         rep["patientSystolic"] = rep.pop("patient_systolic")


### PR DESCRIPTION
### Purpose
To create an endpoint that allows either a patient or a clinician that has a relationship with the patient to view patient data and creates a log when viewed

### Files Changed
- Created the endpoint that allows the patient or clinician to view a patients data while creating a log when viewed in `records.py`
- Created a serializer for the patients data in `records.py`

### Testing
Fetch, then run the following commands in the project root directory
```
pipenv shell
```
```
pipenv install
```
```
./seed_database.sh
```
Then confirm the following:
- When you send a GET request to `http://localhost:8000/records/{recordId}` if you are the patient or clinician that is tied to the given patient data you will return that data
  - If you are not authorized to view the data you will return a 403 FORBIDDEN 
- IF for any reason the log fails to be created you will return a 500 INTERNAL_SERVER_ERROR

closes #37 