### PR TITLE
Fetch Most Recent Patient Record of Specific Patient

### DIFF
--- a/gondorapi/serializers/clinicians.py
+++ b/gondorapi/serializers/clinicians.py
@@ -1,7 +1,5 @@
-from gondorapi.models import Address, AddressType, Appointment, Log, PatientClinician, PatientData, RescheduleRequest, State, User, UserAddress
-from django.contrib.auth.hashers import check_password
+from gondorapi.models import PatientClinician, User
 from rest_framework import serializers
-import datetime
 
 
 class ClinicianSerializers:


### PR DESCRIPTION
### Purpose
To allow a Clinician to see the most recent vitals recorded of a specific Patient that they are a provider of

### Files Changed
- Added an endpoint that returns the most recent vitals of a patient in `/views/users.py`

### To Test
Fetch, then run the following commands in the project root directory
```
pipenv shell
```
```
pipenv install
```
```
./seed_database.sh
```
Then confirm the following:
- When logged in as a Clinician
   - GET request to `/users/{userId}/records/last` returns the vitals recorded from their most recent Patient Data, and a Log is created
   - GET request to `/users/{userId}/records/last` with a User Id of a non-patient returns a 400 Bad Request
   - GET request to `/users/{userId}/records/last` of a Patient without any Patient Data returns a 404 No Content
   - GET request to `/users/{userId}/records/last` of a Patient you are not a provider for returns a 403 Forbidden
 - When NOT logged in as a Clinician
    - GET request to `/users/{userId}/records/last` returns a 403 Forbidden