### PR TITLE
Edit Patient Data

### DIFF
--- a/gondorapi/serializers/patient_data.py
+++ b/gondorapi/serializers/patient_data.py
@@ -1,6 +1,7 @@
 from gondorapi.models import PatientData
 from gondorapi.serializers import EmbeddedSerializers
 from rest_framework import serializers
+import datetime
 
 
 class PatientDataSerializers:
@@ -59,3 +60,26 @@ class PatientDataSerializers:
             rep["patientDiastolic"] = rep.pop("patient_diastolic")
             rep["patientWeightKg"] = rep.pop("patient_weight_kg")
             return rep
+    
+
+    class PatientDataEditSerializer(serializers.ModelSerializer):
+        class Meta:
+            model = PatientData
+            fields = ["patient_systolic", "patient_diastolic", "patient_weight_kg", "clinician_notes"]
+        
+        def to_internal_value(self, data):
+            data = data.copy()
+            data["patient_systolic"] = data.pop("patientSystolic")
+            data["patient_diastolic"] = data.pop("patientDiastolic")
+            data["patient_weight_kg"] = data.pop("patientWeightKg")
+            data["clinician_notes"] = data.pop("clinicianNotes")
+            return super().to_internal_value(data)
+        
+        def update(self, instance, validated_data):
+            instance.patient_systolic = validated_data["patient_systolic"]
+            instance.patient_diastolic = validated_data["patient_diastolic"]
+            instance.patient_weight_kg = validated_data["patient_weight_kg"]
+            instance.clinician_notes = validated_data["clinician_notes"]
+            instance.updated_by = self.context["request"].user
+            instance.save()
+            return instance

--- a/gondorapi/views/records.py
+++ b/gondorapi/views/records.py
@@ -1,4 +1,4 @@
-from gondorapi.models import PatientData, Log
+from gondorapi.models import PatientData, Log, PatientClinician
 from rest_framework import viewsets, status
 from rest_framework.decorators import action
 from rest_framework.response import Response
@@ -50,4 +50,27 @@ class RecordViewSet(viewsets.ViewSet):
         serializer = PatientDataSerializers.PatientDataSerializer(found_record)
         return Response(serializer.data)
     
+    def update(self, request, pk=None):
+        requester = request.user
+        is_clinician = requester.groups.filter(name="Clinician").exists()
+        if not is_clinician:
+            return Response("You are not a Clinician", status=status.HTTP_403_FORBIDDEN)
+        
+        try:
+            record = PatientData.objects.get(pk=pk)
+            patient = record.patient
 
+            is_provider = PatientClinician.objects.filter(patient=patient, clinician=requester).exists()
+            is_creator = requester == record.created_by
+            if not is_provider and not is_creator:
+                return Response("You are not allowed to edit this Medical Record", status=status.HTTP_403_FORBIDDEN)
+            
+            serializer = PatientDataSerializers.PatientDataEditSerializer(record, request.data, context={"request": request})
+            if serializer.is_valid():
+                serializer.save()
+                return Response(status=status.HTTP_204_NO_CONTENT)
+            
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+        
+        except PatientData.DoesNotExist:
+            return Response("Medical Record does not exist", status=status.HTTP_404_NOT_FOUND)


### PR DESCRIPTION
### Purpose
To allow Clinicians to edit already created Patient Data/Medical Records, so long as they either created it, or are a provider for the Patient

### Files Changed
- Added a serializer that checks the validity of the new data, and then updates the record if valid in `/serializers/patient-data.py`
- Added an endpoint that allows Clinicians to edit Patient Data/Medical Records if they have permission in `/views/records.py`

### To Test
Fetch, then run the following commands in the project root directory
```
pipenv shell
```
```
pipenv install
```
```
./seed_database.sh
```
Then confirm the following:
- When logged in as a Clinician
   - PUT request to `/records/{recordId}` with a valid Patient Data/Medical Record Id, the Clinician has permission, and with valid JSON edits the appropriate record and returns a 204 No Content
   - PUT request to `/records/{recordId}` without permission returns a 403 Forbidden
   - PUT request to `/records/{recordId}` with a valid Id and permission, but invalid JSON returns a 400 Bad Request with details on what is incorrect
- When NOT logged in as a Clinician
   - PUT request to `/records/{recordId}` returns a 403 Forbidden

closes #39 