### PR TITLE
Cc/feature/41/unshare notes

### DIFF
--- a/gondorapi/views/records.py
+++ b/gondorapi/views/records.py
@@ -5,7 +5,7 @@ from rest_framework.response import Response
 from gondorapi.serializers import PatientDataSerializers
 from django.db.models import Q
 from django.shortcuts import get_object_or_404
-
+from django.utils import timezone
 
 class RecordViewSet(viewsets.ViewSet):
     @action(detail=False, methods=["get"], url_path="me")
@@ -122,6 +122,8 @@ class RecordViewSet(viewsets.ViewSet):
                 return Response({"Notes already not shared."}, status=status.HTTP_400_BAD_REQUEST)
             
             record.is_notes_shared = False
+            record.updated_by = requester
+            record.updated_timestamp = timezone.now()
             record.save()
             return Response(status=status.HTTP_204_NO_CONTENT)
         

--- a/gondorapi/views/records.py
+++ b/gondorapi/views/records.py
@@ -101,6 +101,33 @@ class RecordViewSet(viewsets.ViewSet):
         except Appointment.DoesNotExist:
             return Response({"Appointment does not exist"}, status=status.HTTP_400_BAD_REQUEST)
         
+    
+    @action(detail=True, methods=["put"], url_path="unshare")
+    def unshare_notes(self,request,pk=None):
+        requester = request.user
+        is_clinician = requester.groups.filter(name="Clinician").exists()
+        if not is_clinician:
+            return Response("You are not a Clinician", status=status.HTTP_403_FORBIDDEN)
+        
+        try:
+            record = PatientData.objects.get(pk=pk)
+            patient = record.patient
+
+            is_provider = PatientClinician.objects.filter(patient=patient, clinician=requester).exists()
+            is_creator = requester == record.created_by
+            if not is_provider and not is_creator:
+                return Response("You are not allowed to edit this Medical Record", status=status.HTTP_403_FORBIDDEN)
+            
+            if record.is_notes_shared == False:
+                return Response({"Notes already not shared."}, status=status.HTTP_400_BAD_REQUEST)
+            
+            record.is_notes_shared = False
+            record.save()
+            return Response(status=status.HTTP_204_NO_CONTENT)
+        
+        except Appointment.DoesNotExist:
+            return Response({"Appointment does not exist"}, status=status.HTTP_404_NOT_FOUND)
+        
        
 
 


### PR DESCRIPTION
### Purpose
To allow a Clinician to change the value of is_notes_shared on patient data to false

### Files Changed 
- Created a view that allows a clinician that has a relationship with the patient data to change is_notes_share to false in `views/records.py`

### Testing 
Fetch, then run the following commands in the project root directory
```
pipenv shell
```
```
pipenv install
```
```
./seed_database.sh
```
Then confirm the following:
- When logged in as a Clinician 
   - When you send a PUT request to `http://localhost:8000/records/{Patient_dataID}/unshare` if you have a relationship with that data the is_notes_shared property will be changed to False
   - IF you do NOT have a relationship with the data you will return a 403 stating that you are not allowed to edit this data
- IF the notes are already NOT shared, you will return a 400 stating that the notes are already not shared 
- IF you are NOT a Clinician:
   - When you send a PUT request to `http://localhost:8000/records/{Patient_dataID}/unshare` you will return a 403 stating that you are not a clinician
 

Closes #41 